### PR TITLE
Make database path configurable with an environment variable

### DIFF
--- a/lib/csv_record/connector.rb
+++ b/lib/csv_record/connector.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 module CsvRecord::Connector
-  DATABASE_FOLDER = 'db'.freeze
+  BASE_PATH = ENV['ARCHIVE_PATH'].nil? ? "." : ENV['ARCHIVE_PATH']
+  DATABASE_FOLDER =  File.join(BASE_PATH, 'db')
   APPEND_MODE = 'a'.freeze
   WRITE_MODE = 'wb'.freeze
   READ_MODE = 'r'.freeze


### PR DESCRIPTION
Hi,
thanks for this nice GEM.
I'm using in a personal project and I need to move the `db` folder in a different path.

I think that an Environment Variable can be used in this case to define the path of the `db`.

This PR is just to check if you like the idea,  several tests are broken and documentation is missin. I want just to know your opinion about adding this feature.

thanks.