### PR TITLE
Add an env variable to customize the root folder for the archive

### DIFF
--- a/lib/csv_record/connector.rb
+++ b/lib/csv_record/connector.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
 module CsvRecord::Connector
-  DATABASE_FOLDER = 'db'.freeze
   APPEND_MODE = 'a'.freeze
   WRITE_MODE = 'wb'.freeze
   READ_MODE = 'r'.freeze
 
+  # Return the folder where the archive will be stored.
+  def self.database_folder
+    root_folder =  ENV['CSV_RECORD_ARCHIVE_PATH'] || "."
+    return File.join( root_folder, 'db')
+  end
+
   # Checks wheter the database directory exists
   def __initialize_db_directory__
-    unless Dir.exist?(DATABASE_FOLDER)
-      Dir.mkdir DATABASE_FOLDER
+    unless Dir.exist?(CsvRecord::Connector.database_folder)
+      Dir.mkdir CsvRecord::Connector.database_folder
     end
   end
 

--- a/lib/csv_record/writer.rb
+++ b/lib/csv_record/writer.rb
@@ -45,8 +45,8 @@ module CsvRecord::Writer
         send :remove_const, 'DATABASE_LOCATION_TMP'
       end
 
-      const_set 'DATABASE_LOCATION', "db/#{@table_name}.csv"
-      const_set 'DATABASE_LOCATION_TMP', "db/#{@table_name}_tmp.csv"
+      const_set 'DATABASE_LOCATION', "#{CsvRecord::Connector::database_folder}/#{@table_name}.csv"
+      const_set 'DATABASE_LOCATION_TMP', "#{CsvRecord::Connector::database_folder}/#{@table_name}_tmp.csv"
     end
 
     alias :create :__create__

--- a/test/csv_record/connector_test.rb
+++ b/test/csv_record/connector_test.rb
@@ -11,7 +11,8 @@ describe CsvRecord::Connector do
   describe 'validating the methods behavior' do
     it "Creates the database folder" do
       Jedi.initialize_db_directory.wont_be_nil
-      Dir.exist?('db').must_equal true
+
+      Dir.exist?(CsvRecord::Connector::database_folder).must_equal true
     end
 
     it "Checks the database initialization state" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,7 +16,7 @@ class MiniTest::Spec
   include TestHelpers
 
   after :each do
-    FileUtils.rm_rf 'db'
+    FileUtils.rm_rf CsvRecord::Connector::database_folder
   end
 
   let(:jedi_council) { JediOrder.build rank: 'council' }


### PR DESCRIPTION
## What?
With this request, the root folder of the archive can be customized setting an environment variable called `CSV_RECORD_ARCHIVE_PATH`.
All the `csv` files are still stored inside a `db` folder, but this folder can be either placed in the project home or wherever the user needs.

## Why? 
I'm dockerizing a script I created and I would like to keep the archive outside the folder with the code. The latter will be included into the docker container, the archive will be on the host machine.

## Downside
Naming collision. If multiple projects write on the same archive folder, the risk of naming collision is higher. But on my opinion this should be clear for the user.

_disclaimer:_ This is my first PR in a ruby project :P any suggestion will be appreciate.

Thanks a lot for this gem.
